### PR TITLE
Add REST endpoints and websocket routing for quote and project chat

### DIFF
--- a/green_tech_backend/construction/api/urls.py
+++ b/green_tech_backend/construction/api/urls.py
@@ -17,7 +17,8 @@ from .project_views import (
     ProjectMilestoneViewSet,
     ProjectDocumentViewSet,
     ProjectUpdateViewSet,
-    ProjectTaskViewSet
+    ProjectTaskViewSet,
+    ProjectChatMessageViewSet,
 )
 
 # Create a router and register our viewsets with it
@@ -32,14 +33,16 @@ router.register(r'projects', ProjectViewSet, basename='project')
 
 # Nested router for project milestones
 project_router = SimpleRouter()
-project_router.register(r'milestones', ProjectMilestoneViewSet, 
+project_router.register(r'milestones', ProjectMilestoneViewSet,
                        basename='project-milestone')
-project_router.register(r'documents', ProjectDocumentViewSet, 
+project_router.register(r'documents', ProjectDocumentViewSet,
                        basename='project-document')
-project_router.register(r'updates', ProjectUpdateViewSet, 
+project_router.register(r'updates', ProjectUpdateViewSet,
                        basename='project-update')
-project_router.register(r'tasks', ProjectTaskViewSet, 
+project_router.register(r'tasks', ProjectTaskViewSet,
                        basename='project-task')
+project_router.register(r'chat-messages', ProjectChatMessageViewSet,
+                       basename='project-chat-message')
 
 # Quote endpoints with nested routes for items
 quote_router = SimpleRouter()

--- a/green_tech_backend/construction/routing.py
+++ b/green_tech_backend/construction/routing.py
@@ -1,9 +1,7 @@
 from django.urls import path
 
 from .consumers import ProjectChatConsumer
-from quotes.consumers import QuoteChatConsumer
 
 websocket_urlpatterns = [
     path('ws/projects/<int:project_id>/chat/', ProjectChatConsumer.as_asgi()),
-    path('ws/quotes/<uuid:quote_id>/chat/', QuoteChatConsumer.as_asgi()),
 ]

--- a/green_tech_backend/core/asgi.py
+++ b/green_tech_backend/core/asgi.py
@@ -21,12 +21,18 @@ except Exception:  # pragma: no cover
     lead_ws = []
 
 try:
+    from quotes.routing import websocket_urlpatterns as quote_ws
+except Exception:  # pragma: no cover
+    quote_ws = []
+
+try:
     from construction.routing import websocket_urlpatterns as construction_ws
 except Exception:  # pragma: no cover
     construction_ws = []
 
 websocket_urlpatterns.extend(plan_ws)
 websocket_urlpatterns.extend(lead_ws)
+websocket_urlpatterns.extend(quote_ws)
 websocket_urlpatterns.extend(construction_ws)
 
 application = ProtocolTypeRouter(

--- a/green_tech_backend/core/settings.py
+++ b/green_tech_backend/core/settings.py
@@ -166,6 +166,7 @@ if os.environ.get('POSTGRES_DB'):
             'PASSWORD': os.environ.get('POSTGRES_PASSWORD', ''),
             'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
             'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+            'TEST': {'SERIALIZE': False},
         }
     }
 else:
@@ -173,6 +174,7 @@ else:
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': BASE_DIR / 'db.sqlite3',
+            'TEST': {'SERIALIZE': False},
         }
     }
 

--- a/green_tech_backend/quotes/permissions.py
+++ b/green_tech_backend/quotes/permissions.py
@@ -1,0 +1,57 @@
+"""Permission helpers for quote chat access control."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.contrib.auth import get_user_model
+from rest_framework.permissions import BasePermission
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers
+    from django.contrib.auth.models import AbstractBaseUser
+    from .models import Quote
+
+User = get_user_model()
+
+
+def user_can_access_quote_chat(quote: 'Quote', user: 'AbstractBaseUser') -> bool:
+    """Return True when the user can interact with the quote chat thread."""
+
+    if not user or not user.is_authenticated:
+        return False
+    if user.is_staff or user.is_superuser:
+        return True
+
+    build_request = getattr(quote, 'build_request', None)
+    if build_request and getattr(build_request, 'user_id', None) == user.id:
+        return True
+
+    email = (getattr(user, 'email', '') or '').lower()
+    if not email:
+        return False
+
+    candidate_emails = [
+        getattr(quote, 'prepared_by_email', None),
+        getattr(quote, 'recipient_email', None),
+        getattr(build_request, 'contact_email', None) if build_request else None,
+    ]
+    return any(candidate and candidate.lower() == email for candidate in candidate_emails)
+
+
+class QuoteChatAccessPermission(BasePermission):
+    """DRF permission ensuring the requester can access a quote chat."""
+
+    message = 'You do not have permission to interact with this quote chat.'
+
+    def has_permission(self, request, view) -> bool:
+        return bool(request.user and request.user.is_authenticated)
+
+    def has_object_permission(self, request, view, obj) -> bool:
+        from .models import Quote  # Imported lazily to avoid circular imports.
+
+        if isinstance(obj, Quote):
+            quote = obj
+        else:
+            quote = getattr(obj, 'quote', None)
+        if quote is None:
+            return False
+        return user_can_access_quote_chat(quote, request.user)

--- a/green_tech_backend/quotes/realtime.py
+++ b/green_tech_backend/quotes/realtime.py
@@ -1,0 +1,25 @@
+"""Utilities for broadcasting quote chat events over Channels."""
+from __future__ import annotations
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from .serializers import QuoteMessageSerializer
+
+GROUP_TEMPLATE = 'quote-chat-{quote_id}'
+
+
+def broadcast_quote_message(message) -> None:
+    """Send a new quote chat message payload to connected WebSocket clients."""
+
+    layer = get_channel_layer()
+    if not layer:
+        return
+    serializer = QuoteMessageSerializer(message, context={'request': None})
+    async_to_sync(layer.group_send)(
+        GROUP_TEMPLATE.format(quote_id=message.quote_id),
+        {
+            'type': 'chat.message',
+            'payload': serializer.data,
+        },
+    )

--- a/green_tech_backend/quotes/routing.py
+++ b/green_tech_backend/quotes/routing.py
@@ -1,0 +1,8 @@
+"""Quote app websocket routing configuration."""
+from django.urls import path
+
+from .consumers import QuoteChatConsumer
+
+websocket_urlpatterns = [
+    path('ws/quotes/<uuid:quote_id>/chat/', QuoteChatConsumer.as_asgi()),
+]

--- a/green_tech_backend/quotes/tests/test_chat_api.py
+++ b/green_tech_backend/quotes/tests/test_chat_api.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import patch
+import types
+
+import pytest
+from rest_framework.test import APIClient
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_save
+from django.urls import include, path
+
+from locations.models import Region
+from plans.models import BuildRequest, Plan, PlanStyle
+from plans.signals import plan_post_save
+from quotes.models import Quote, QuoteChatMessage, QuoteMessageReceipt
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db()
+
+
+@pytest.fixture()
+def api_client() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture(autouse=True)
+def override_urls(settings):
+    urlconf = types.ModuleType('test_urls_quotes')
+    urlconf.urlpatterns = [
+        path('api/', include('quotes.urls')),
+    ]
+    settings.ROOT_URLCONF = urlconf
+
+
+@pytest.fixture()
+def quote_setup() -> dict[str, object]:
+    region = Region.objects.create(
+        slug='greater-accra',
+        name='Greater Accra',
+        country='Ghana',
+        currency_code='GHS',
+        cost_multiplier=Decimal('1.10'),
+    )
+
+    post_save.disconnect(plan_post_save, sender=Plan)
+    try:
+        plan = Plan.objects.create(
+            slug='solar-bungalow',
+            name='Solar Bungalow',
+            style=PlanStyle.BUNGALOW,
+            bedrooms=3,
+            bathrooms=2,
+            floors=1,
+            area_sq_m=Decimal('145.00'),
+            base_price=Decimal('120000.00'),
+            base_currency='USD',
+        )
+    finally:
+        post_save.connect(plan_post_save, sender=Plan)
+
+    customer = User.objects.create_user(
+        email='customer@example.com', password='testpass', first_name='Customer'
+    )
+    agent = User.objects.create_user(
+        email='agent@example.com', password='testpass', first_name='Agent'
+    )
+    outsider = User.objects.create_user(
+        email='unrelated@example.com', password='testpass', first_name='Other'
+    )
+
+    request = BuildRequest.objects.create(
+        plan=plan,
+        region=region,
+        user=customer,
+        contact_name='Customer Name',
+        contact_email=customer.email,
+        contact_phone='+233555000000',
+        budget_currency='USD',
+    )
+
+    quote = Quote.objects.create(build_request=request, region=region)
+    quote.prepared_by_email = agent.email
+    quote.save(update_fields=['prepared_by_email'])
+
+    QuoteChatMessage.objects.create(
+        quote=quote,
+        sender=agent,
+        body='Initial quote discussion.',
+    )
+
+    return {
+        'quote': quote,
+        'customer': customer,
+        'agent': agent,
+        'outsider': outsider,
+    }
+
+
+def _chat_url(quote: Quote) -> str:
+    return f'/api/quotes/{quote.pk}/messages/'
+
+
+def test_quote_chat_list_for_customer(api_client: APIClient, quote_setup: dict[str, object]):
+    api_client.force_authenticate(quote_setup['customer'])
+    response = api_client.get(_chat_url(quote_setup['quote']))
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['count'] == 1
+    assert payload['results'][0]['body'] == 'Initial quote discussion.'
+
+
+def test_quote_chat_rejects_unrelated_user(api_client: APIClient, quote_setup: dict[str, object]):
+    api_client.force_authenticate(quote_setup['outsider'])
+    response = api_client.get(_chat_url(quote_setup['quote']))
+    assert response.status_code == 403
+
+
+@patch('quotes.views.broadcast_quote_message')
+def test_quote_chat_create_records_receipt(
+    mock_broadcast,
+    api_client: APIClient,
+    quote_setup: dict[str, object],
+):
+    api_client.force_authenticate(quote_setup['customer'])
+    response = api_client.post(
+        _chat_url(quote_setup['quote']),
+        {'body': 'Customer has a question about pricing.'},
+        format='json',
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data['body'] == 'Customer has a question about pricing.'
+    assert QuoteMessageReceipt.objects.filter(
+        message_id=data['id'],
+        user=quote_setup['customer'],
+    ).exists()
+    mock_broadcast.assert_called_once()

--- a/green_tech_backend/quotes/urls.py
+++ b/green_tech_backend/quotes/urls.py
@@ -1,9 +1,10 @@
 from rest_framework.routers import DefaultRouter
 
-from .views import QuoteViewSet
+from .views import QuoteMessageViewSet, QuoteViewSet
 
 
 router = DefaultRouter()
 router.register('quotes', QuoteViewSet, basename='quote')
+router.register(r'quotes/(?P<quote_pk>[^/.]+)/messages', QuoteMessageViewSet, basename='quote-message')
 
 urlpatterns = router.urls


### PR DESCRIPTION
## Summary
- add project and quote chat REST viewsets with permission checks and websocket broadcasts
- register new websocket routes and refactor quote consumer permission helper for reuse
- introduce quote chat API tests and disable test DB serialization warnings

## Testing
- pytest green_tech_backend/quotes/tests/test_chat_api.py

------
https://chatgpt.com/codex/tasks/task_e_68daaab8876483269dff75a8cb13fab5