### PR TITLE
Polish remaining customer in-app property/project flows

### DIFF
--- a/green-tech-africa/src/components/account/AccountPageHeader.tsx
+++ b/green-tech-africa/src/components/account/AccountPageHeader.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+interface AccountPageHeaderProps {
+  title: string;
+  description: string;
+  icon?: ReactNode;
+  actions?: ReactNode;
+}
+
+const AccountPageHeader = ({ title, description, icon, actions }: AccountPageHeaderProps) => {
+  return (
+    <section className="border-b border-border/70 bg-gradient-to-b from-accent/30 to-background py-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
+        <div>
+          <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+            {icon}
+            Customer In-App
+          </div>
+          <h1 className="text-2xl font-bold md:text-3xl">{title}</h1>
+          <p className="mt-1 text-sm text-muted-foreground md:text-base">{description}</p>
+        </div>
+        {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+      </div>
+    </section>
+  );
+};
+
+export default AccountPageHeader;

--- a/green-tech-africa/src/components/layout/Footer.tsx
+++ b/green-tech-africa/src/components/layout/Footer.tsx
@@ -1,160 +1,80 @@
-import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { 
-  Leaf, 
-  MapPin, 
-  Phone, 
-  Mail, 
-  Facebook, 
-  Twitter, 
-  Instagram, 
-  Linkedin,
-  MessageCircle
-} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Facebook, Instagram, Leaf, Linkedin, Mail, MapPin, MessageCircle, Phone, Twitter } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const Footer = () => {
   return (
-    <footer className="bg-professional text-professional-foreground">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          {/* Company Info */}
-          <div className="space-y-4">
-            <Link to="/" className="flex items-center space-x-2">
-              <div className="flex items-center justify-center w-10 h-10 hero-gradient rounded-lg">
-                <Leaf className="w-6 h-6 text-primary-foreground" />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-xl font-bold text-professional-foreground">
-                  Green Tech
-                </span>
-                <span className="text-xs text-professional-foreground/70 -mt-1">
-                  Africa
-                </span>
-              </div>
-            </Link>
-            <p className="text-professional-foreground/80 text-sm leading-relaxed">
-              Leading construction and real estate company in Africa, 
-              committed to sustainable development and innovative green technology.
-            </p>
-            <div className="flex space-x-3">
-              <Button size="icon" variant="ghost" className="text-professional-foreground/70 hover:text-success hover:bg-professional-foreground/10">
-                <Facebook className="h-4 w-4" />
-              </Button>
-              <Button size="icon" variant="ghost" className="text-professional-foreground/70 hover:text-success hover:bg-professional-foreground/10">
-                <Twitter className="h-4 w-4" />
-              </Button>
-              <Button size="icon" variant="ghost" className="text-professional-foreground/70 hover:text-success hover:bg-professional-foreground/10">
-                <Instagram className="h-4 w-4" />
-              </Button>
-              <Button size="icon" variant="ghost" className="text-professional-foreground/70 hover:text-success hover:bg-professional-foreground/10">
-                <Linkedin className="h-4 w-4" />
-              </Button>
+    <footer className="mt-16 border-t border-border/70 bg-background">
+      <div className="mx-auto grid max-w-7xl gap-10 px-4 py-12 sm:px-6 lg:grid-cols-12 lg:px-8">
+        <div className="space-y-4 lg:col-span-4">
+          <Link to="/" className="flex items-center gap-2">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl hero-gradient">
+              <Leaf className="h-5 w-5 text-primary-foreground" />
             </div>
-          </div>
-
-          {/* Quick Links */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">Quick Links</h3>
-            <div className="space-y-2">
-              {[
-                { name: "About Us", path: "/about" },
-                { name: "Our Services", path: "/services" },
-                { name: "Projects", path: "/projects" },
-                { name: "Properties", path: "/properties" },
-                { name: "Contact", path: "/contact" },
-              ].map((link) => (
-                <Link
-                  key={link.name}
-                  to={link.path}
-                  className="block text-professional-foreground/80 hover:text-success smooth-transition text-sm"
-                >
-                  {link.name}
-                </Link>
-              ))}
+            <div className="leading-none">
+              <div className="text-lg font-bold">Green Tech</div>
+              <div className="text-xs text-muted-foreground">Africa</div>
             </div>
-          </div>
-
-          {/* Services */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">Our Services</h3>
-            <div className="space-y-2">
-              {[
-                "Residential Construction",
-                "Commercial Development", 
-                "Property Management",
-                "Real Estate Sales",
-                "Green Building Consulting",
-                "Infrastructure Development"
-              ].map((service) => (
-                <div
-                  key={service}
-                  className="text-professional-foreground/80 text-sm"
-                >
-                  {service}
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Contact Info */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">Contact Us</h3>
-            <div className="space-y-3">
-              <div className="flex items-start space-x-3">
-                <MapPin className="h-4 w-4 text-success mt-1 flex-shrink-0" />
-                <div className="text-professional-foreground/80 text-sm">
-                  123 Green Tech Plaza<br />
-                  Nairobi, Kenya<br />
-                  P.O. Box 12345
-                </div>
-              </div>
-              <div className="flex items-center space-x-3">
-                <Phone className="h-4 w-4 text-success flex-shrink-0" />
-                <div className="text-professional-foreground/80 text-sm">
-                  +254 700 123 456
-                </div>
-              </div>
-              <div className="flex items-center space-x-3">
-                <Mail className="h-4 w-4 text-success flex-shrink-0" />
-                <div className="text-professional-foreground/80 text-sm">
-                  info@greentechafrica.com
-                </div>
-              </div>
-              <Button 
-                variant="success" 
-                size="sm" 
-                className="w-full mt-4"
-                asChild
-              >
-                <a href="https://wa.me/254700123456" target="_blank" rel="noopener noreferrer">
-                  <MessageCircle className="h-4 w-4 mr-2" />
-                  WhatsApp Us
-                </a>
+          </Link>
+          <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+            End-to-end construction and real estate services designed for modern African cities, with a deep focus on sustainability.
+          </p>
+          <div className="flex items-center gap-2">
+            {[Facebook, Twitter, Instagram, Linkedin].map((Icon, idx) => (
+              <Button key={idx} size="icon" variant="outline" className="h-9 w-9 rounded-full">
+                <Icon className="h-4 w-4" />
               </Button>
-            </div>
+            ))}
           </div>
         </div>
 
-        {/* Bottom Bar */}
-        <div className="border-t border-professional-foreground/20 mt-8 pt-8">
-          <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
-            <div className="text-professional-foreground/70 text-sm">
-              © 2025 Green Tech Africa. All rights reserved.
-            </div>
-            <div className="flex space-x-6 text-sm">
-              <Link 
-                to="/privacy" 
-                className="text-professional-foreground/70 hover:text-success smooth-transition"
-              >
-                Privacy Policy
+        <div className="lg:col-span-2">
+          <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground">Company</h3>
+          <div className="space-y-2 text-sm">
+            {[
+              ["About Us", "/about"],
+              ["Services", "/services"],
+              ["Projects", "/projects"],
+              ["Properties", "/properties"],
+            ].map(([label, path]) => (
+              <Link key={label} to={path} className="block text-muted-foreground hover:text-primary">
+                {label}
               </Link>
-              <Link 
-                to="/terms" 
-                className="text-professional-foreground/70 hover:text-success smooth-transition"
-              >
-                Terms of Service
-              </Link>
-            </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="lg:col-span-3">
+          <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground">Contact</h3>
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <div className="flex gap-2"><MapPin className="mt-0.5 h-4 w-4 text-primary" /> Nairobi, Kenya</div>
+            <div className="flex gap-2"><Phone className="mt-0.5 h-4 w-4 text-primary" /> +254 700 123 456</div>
+            <div className="flex gap-2"><Mail className="mt-0.5 h-4 w-4 text-primary" /> info@greentechafrica.com</div>
+          </div>
+          <Button variant="outline" size="sm" className="mt-4" asChild>
+            <a href="https://wa.me/254700123456" target="_blank" rel="noopener noreferrer">
+              <MessageCircle className="mr-2 h-4 w-4" /> WhatsApp us
+            </a>
+          </Button>
+        </div>
+
+        <div className="lg:col-span-3">
+          <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground">Stay Updated</h3>
+          <p className="mb-3 text-sm text-muted-foreground">Get new property alerts and project updates.</p>
+          <div className="flex gap-2">
+            <Input placeholder="Your email" className="h-10" />
+            <Button variant="hero" className="h-10">Join</Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-border/70">
+        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-3 px-4 py-4 text-xs text-muted-foreground sm:px-6 md:flex-row lg:px-8">
+          <div>© 2025 Green Tech Africa. All rights reserved.</div>
+          <div className="flex gap-4">
+            <Link to="/privacy" className="hover:text-primary">Privacy Policy</Link>
+            <Link to="/terms" className="hover:text-primary">Terms of Service</Link>
           </div>
         </div>
       </div>

--- a/green-tech-africa/src/components/layout/Layout.tsx
+++ b/green-tech-africa/src/components/layout/Layout.tsx
@@ -13,7 +13,7 @@ const Layout = ({ children }: LayoutProps) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="flex min-h-screen flex-col bg-background">
       <Navbar />
       <div className="flex flex-1">
         {isAuthenticated && (
@@ -23,13 +23,11 @@ const Layout = ({ children }: LayoutProps) => {
           />
         )}
         <main
-          className={`flex-grow transition-all duration-300 ${isAuthenticated
-              ? sidebarCollapsed
-                ? "md:ml-16"
-                : "md:ml-64"
-              : ""
-            }`}
+          className={`flex-grow transition-all duration-300 ${
+            isAuthenticated ? (sidebarCollapsed ? "md:ml-16" : "md:ml-64") : ""
+          }`}
         >
+          {!isAuthenticated && <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,theme(colors.primary/10),transparent_45%),radial-gradient(circle_at_bottom_left,theme(colors.accent/40),transparent_35%)]" />}
           {children}
         </main>
       </div>

--- a/green-tech-africa/src/components/layout/Navbar.tsx
+++ b/green-tech-africa/src/components/layout/Navbar.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Menu, X, Leaf } from "lucide-react";
+import { Menu, X, Leaf, Sparkles } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,7 +18,6 @@ const Navbar = () => {
   const { user, logout, isAuthenticated } = useAuth();
   const location = useLocation();
 
-  // Public navigation items (when not authenticated)
   const publicNavItems = [
     { name: "Home", path: "/" },
     { name: "About", path: "/about" },
@@ -29,17 +28,17 @@ const Navbar = () => {
     { name: "Contact", path: "/contact" },
   ];
 
-  // Authenticated navigation items (in-app features)
   const authNavItems = [
     { name: "Dashboard", path: "/account" },
     { name: "Plans", path: "/plans" },
-    { name: "Properties", path: "/account/properties" }, // Authenticated catalog view
-    { name: "Projects", path: "/account/projects" }, // Authenticated catalog view
+    { name: "Properties", path: "/account/properties" },
+    { name: "Projects", path: "/account/projects" },
   ];
 
   const navItems = isAuthenticated ? authNavItems : publicNavItems;
 
-  const isActive = (path: string) => location.pathname === path;
+  const isActive = (path: string) =>
+    location.pathname === path || (path !== "/" && location.pathname.startsWith(path));
 
   const handleSignOut = () => {
     logout();
@@ -47,34 +46,28 @@ const Navbar = () => {
   };
 
   return (
-    <nav className="bg-background/95 backdrop-blur-sm border-b border-border sticky top-0 z-50 shadow-soft">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
-          {/* Logo */}
-          <Link to="/" className="flex items-center space-x-2">
-            <div className="flex items-center justify-center w-10 h-10 hero-gradient rounded-lg">
-              <Leaf className="w-6 h-6 text-primary-foreground" />
+    <nav className="sticky top-0 z-50 border-b border-border/60 bg-background/90 backdrop-blur-xl">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <Link to="/" className="group flex items-center gap-2.5">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl hero-gradient shadow-soft">
+              <Leaf className="h-5 w-5 text-primary-foreground" />
             </div>
-            <div className="flex flex-col">
-              <span className="text-xl font-bold text-foreground">
-                Green Tech
-              </span>
-              <span className="text-xs text-muted-foreground -mt-1">
-                Africa
-              </span>
+            <div className="flex flex-col leading-none">
+              <span className="text-base font-bold text-foreground md:text-lg">Green Tech</span>
+              <span className="-mt-0.5 text-xs text-muted-foreground">Africa</span>
             </div>
           </Link>
 
-          {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8">
+          <div className="hidden items-center gap-2 rounded-full border border-border/70 bg-background/70 p-1 md:flex">
             {navItems.map((item) => (
               <Link
                 key={item.name}
                 to={item.path}
-                className={`text-sm font-medium smooth-transition ${
+                className={`rounded-full px-4 py-2 text-sm font-medium smooth-transition ${
                   isActive(item.path)
-                    ? "text-primary"
-                    : "text-muted-foreground hover:text-primary"
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground"
                 }`}
               >
                 {item.name}
@@ -82,8 +75,7 @@ const Navbar = () => {
             ))}
           </div>
 
-          {/* Desktop CTA */}
-          <div className="hidden md:flex items-center space-x-4">
+          <div className="hidden items-center gap-2 md:flex">
             {!isAuthenticated ? (
               <>
                 <Button variant="ghost" size="sm" asChild>
@@ -92,8 +84,11 @@ const Navbar = () => {
                 <Button variant="outline" size="sm" asChild>
                   <Link to="/contact">Get Quote</Link>
                 </Button>
-                <Button variant="hero" size="sm" asChild>
-                  <Link to="/properties">View Properties</Link>
+                <Button variant="hero" size="sm" asChild className="shadow-soft">
+                  <Link to="/properties">
+                    <Sparkles className="mr-1.5 h-4 w-4" />
+                    Explore Listings
+                  </Link>
                 </Button>
               </>
             ) : (
@@ -101,8 +96,8 @@ const Navbar = () => {
                 <NotificationBell />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex items-center gap-2">
-                      <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-semibold">
+                    <Button variant="ghost" className="flex items-center gap-2 rounded-full px-2.5">
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
                         {(
                           user?.first_name?.[0]?.toUpperCase() ||
                           user?.last_name?.[0]?.toUpperCase() ||
@@ -110,7 +105,7 @@ const Navbar = () => {
                           "?"
                         )}
                       </div>
-                      <span className="hidden lg:inline-block text-sm font-medium">
+                      <span className="hidden text-sm font-medium lg:inline-block">
                         {user?.first_name ? `${user.first_name} ${user.last_name ?? ""}`.trim() : user?.email}
                       </span>
                     </Button>
@@ -118,28 +113,14 @@ const Navbar = () => {
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>My Account</DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                      <Link to="/account">Dashboard</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link to="/account/requests">My Requests</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link to="/account/quotes">My Quotes</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link to="/account/appointments">Appointments</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link to="/account/favorites">Favorites</Link>
-                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account">Dashboard</Link></DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account/requests">My Requests</Link></DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account/quotes">My Quotes</Link></DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account/appointments">Appointments</Link></DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account/favorites">Favorites</Link></DropdownMenuItem>
                     <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                      <Link to="/account/profile">Profile</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link to="/account/notifications">Notifications</Link>
-                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account/profile">Profile</Link></DropdownMenuItem>
+                    <DropdownMenuItem asChild><Link to="/account/notifications">Notifications</Link></DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={handleSignOut}>Sign out</DropdownMenuItem>
                   </DropdownMenuContent>
@@ -148,65 +129,49 @@ const Navbar = () => {
             )}
           </div>
 
-          {/* Mobile menu button */}
           <div className="md:hidden">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setIsOpen(!isOpen)}
-            >
+            <Button variant="ghost" size="icon" onClick={() => setIsOpen(!isOpen)}>
               {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </Button>
           </div>
         </div>
 
-        {/* Mobile Navigation */}
         {isOpen && (
-          <div className="md:hidden">
-            <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-background border-t border-border">
+          <div className="pb-3 md:hidden">
+            <div className="space-y-1 rounded-xl border border-border/70 bg-background p-2 shadow-soft">
               {navItems.map((item) => (
                 <Link
                   key={item.name}
                   to={item.path}
-                  className={`block px-3 py-2 text-base font-medium smooth-transition ${
+                  className={`block rounded-lg px-3 py-2 text-sm font-medium smooth-transition ${
                     isActive(item.path)
-                      ? "text-primary bg-accent"
-                      : "text-muted-foreground hover:text-primary hover:bg-accent"
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
                   }`}
                   onClick={() => setIsOpen(false)}
                 >
                   {item.name}
                 </Link>
               ))}
-              <div className="pt-4 pb-2 space-y-2">
+              <div className="space-y-2 border-t border-border px-1 pt-3">
                 {!isAuthenticated ? (
                   <>
                     <Button variant="ghost" className="w-full" asChild>
-                      <Link to="/auth/login" onClick={() => setIsOpen(false)}>
-                        Sign In
-                      </Link>
+                      <Link to="/auth/login" onClick={() => setIsOpen(false)}>Sign In</Link>
                     </Button>
                     <Button variant="outline" className="w-full" asChild>
-                      <Link to="/contact" onClick={() => setIsOpen(false)}>
-                        Get Quote
-                      </Link>
+                      <Link to="/contact" onClick={() => setIsOpen(false)}>Get Quote</Link>
                     </Button>
                     <Button variant="hero" className="w-full" asChild>
-                      <Link to="/properties" onClick={() => setIsOpen(false)}>
-                        View Properties
-                      </Link>
+                      <Link to="/properties" onClick={() => setIsOpen(false)}>Explore Listings</Link>
                     </Button>
                   </>
                 ) : (
                   <>
                     <Button variant="outline" className="w-full" asChild>
-                      <Link to="/account/profile" onClick={() => setIsOpen(false)}>
-                        Profile
-                      </Link>
+                      <Link to="/account/profile" onClick={() => setIsOpen(false)}>Profile</Link>
                     </Button>
-                    <Button variant="outline" className="w-full" onClick={handleSignOut}>
-                      Sign out
-                    </Button>
+                    <Button variant="outline" className="w-full" onClick={handleSignOut}>Sign out</Button>
                   </>
                 )}
               </div>

--- a/green-tech-africa/src/components/layout/Sidebar.tsx
+++ b/green-tech-africa/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Building2,
   Home,
   FileCheck,
+  Sparkles,
 } from "lucide-react";
 
 interface SidebarProps {
@@ -29,218 +30,144 @@ const Sidebar = ({ isCollapsed, onToggleCollapse }: SidebarProps) => {
   const { user, logout, isAuthenticated } = useAuth();
   const location = useLocation();
 
-  if (!isAuthenticated) {
-    return null;
-  }
+  if (!isAuthenticated) return null;
 
   const menuItems = [
-    {
-      name: "Dashboard",
-      path: "/account",
-      icon: LayoutDashboard,
-      exact: true,
-    },
-    {
-      name: "Requests",
-      path: "/account/requests",
-      icon: ClipboardList,
-    },
-    {
-      name: "Quotes",
-      path: "/account/quotes",
-      icon: FileSpreadsheet,
-    },
-    {
-      name: "My Properties",
-      path: "/account/my-properties",
-      icon: Home,
-    },
-    {
-      name: "My Projects",
-      path: "/account/my-projects",
-      icon: Building2,
-    },
-    {
-      name: "Property Requests",
-      path: "/account/property-transactions",
-      icon: FileCheck,
-    },
-    {
-      name: "Appointments",
-      path: "/account/appointments",
-      icon: Calendar,
-    },
-    {
-      name: "Messages",
-      path: "/account/messages",
-      icon: MessageSquare,
-    },
-    {
-      name: "Favorites",
-      path: "/account/favorites",
-      icon: Heart,
-    },
-    {
-      name: "Documents",
-      path: "/account/documents",
-      icon: FileText,
-    },
-    {
-      name: "Payments",
-      path: "/account/payments",
-      icon: CreditCard,
-    },
+    { name: "Dashboard", path: "/account", icon: LayoutDashboard, exact: true },
+    { name: "Requests", path: "/account/requests", icon: ClipboardList },
+    { name: "Quotes", path: "/account/quotes", icon: FileSpreadsheet },
+    { name: "My Properties", path: "/account/my-properties", icon: Home },
+    { name: "My Projects", path: "/account/my-projects", icon: Building2 },
+    { name: "Property Requests", path: "/account/property-transactions", icon: FileCheck },
+    { name: "Appointments", path: "/account/appointments", icon: Calendar },
+    { name: "Messages", path: "/account/messages", icon: MessageSquare },
+    { name: "Favorites", path: "/account/favorites", icon: Heart },
+    { name: "Documents", path: "/account/documents", icon: FileText },
+    { name: "Payments", path: "/account/payments", icon: CreditCard },
   ];
 
   const settingsItems = [
-    {
-      name: "Profile",
-      path: "/account/profile",
-      icon: User,
-    },
-    {
-      name: "Notifications",
-      path: "/account/notifications",
-      icon: Bell,
-    },
+    { name: "Profile", path: "/account/profile", icon: User },
+    { name: "Notifications", path: "/account/notifications", icon: Bell },
   ];
 
-  const isActive = (path: string, exact = false) => {
-    if (exact) {
-      return location.pathname === path;
-    }
-    return location.pathname.startsWith(path);
-  };
+  const isActive = (path: string, exact = false) =>
+    exact ? location.pathname === path : location.pathname.startsWith(path);
 
-  const handleSignOut = () => {
-    logout();
-  };
+  const userInitial = (
+    user?.first_name?.[0]?.toUpperCase() ||
+    user?.last_name?.[0]?.toUpperCase() ||
+    user?.email?.[0]?.toUpperCase() ||
+    "?"
+  );
 
   return (
-    <div
-      className={`fixed left-0 top-16 h-[calc(100vh-4rem)] bg-background border-r border-border z-40 transition-all duration-300 hidden md:block ${
-        isCollapsed ? "w-16" : "w-64"
+    <aside
+      className={`fixed left-0 top-16 z-40 hidden h-[calc(100vh-4rem)] border-r border-border/70 bg-background/95 backdrop-blur md:block transition-all duration-300 ${
+        isCollapsed ? "w-16" : "w-72"
       }`}
     >
-      {/* Toggle Button */}
       <div className="absolute -right-3 top-6 z-50">
         <Button
           variant="outline"
           size="icon"
-          className="h-6 w-6 rounded-full bg-background border shadow-md"
+          className="h-7 w-7 rounded-full bg-background shadow-md"
           onClick={() => onToggleCollapse(!isCollapsed)}
         >
-          {isCollapsed ? (
-            <ChevronRight className="h-3 w-3" />
-          ) : (
-            <ChevronLeft className="h-3 w-3" />
-          )}
+          {isCollapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronLeft className="h-3.5 w-3.5" />}
         </Button>
       </div>
 
-      <div className="flex flex-col h-full">
-        {/* User Info */}
-        <div className="p-4 border-b border-border">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-semibold flex-shrink-0">
-              {(
-                user?.first_name?.[0]?.toUpperCase() ||
-                user?.last_name?.[0]?.toUpperCase() ||
-                user?.email?.[0]?.toUpperCase() ||
-                "?"
+      <div className="flex h-full flex-col">
+        <div className="border-b border-border/70 p-3">
+          <div className={`rounded-xl border border-border/70 bg-card p-3 ${isCollapsed ? "items-center" : ""}`}>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary font-semibold text-primary-foreground">
+                {userInitial}
+              </div>
+              {!isCollapsed && (
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold">
+                    {user?.first_name ? `${user.first_name} ${user.last_name ?? ""}`.trim() : user?.email}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">{user?.email}</p>
+                </div>
               )}
             </div>
             {!isCollapsed && (
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium truncate">
-                  {user?.first_name
-                    ? `${user.first_name} ${user.last_name ?? ""}`.trim()
-                    : user?.email}
-                </p>
-                <p className="text-xs text-muted-foreground truncate">
-                  {user?.email}
-                </p>
-              </div>
+              <Link
+                to="/account/requests/new"
+                className="mt-3 flex items-center justify-center gap-2 rounded-lg bg-primary/10 px-3 py-2 text-xs font-medium text-primary hover:bg-primary/15"
+              >
+                <Sparkles className="h-3.5 w-3.5" /> Start New Request
+              </Link>
             )}
           </div>
         </div>
 
-        {/* Navigation */}
-        <div className="flex-1 overflow-y-auto py-4">
-          <nav className="space-y-1 px-3">
-            {/* Main Menu */}
-            <div className="space-y-1">
-              {menuItems.map((item) => {
-                const Icon = item.icon;
-                const active = isActive(item.path, item.exact);
-                
-                return (
-                  <Link
-                    key={item.path}
-                    to={item.path}
-                    className={`flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-                      active
-                        ? "bg-primary text-primary-foreground"
-                        : "text-muted-foreground hover:text-foreground hover:bg-accent"
-                    }`}
-                    title={isCollapsed ? item.name : undefined}
-                  >
-                    <Icon className="h-4 w-4 flex-shrink-0" />
-                    {!isCollapsed && <span className="truncate">{item.name}</span>}
-                  </Link>
-                );
-              })}
-            </div>
+        <div className="flex-1 overflow-y-auto px-2 py-3">
+          <nav className="space-y-1.5">
+            {menuItems.map((item) => {
+              const Icon = item.icon;
+              const active = isActive(item.path, item.exact);
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  title={isCollapsed ? item.name : undefined}
+                  className={`group flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${
+                    active
+                      ? "bg-primary/10 font-medium text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                >
+                  <Icon className={`h-4 w-4 shrink-0 ${active ? "text-primary" : ""}`} />
+                  {!isCollapsed && <span className="truncate">{item.name}</span>}
+                </Link>
+              );
+            })}
+          </nav>
 
-            {/* Settings Section */}
-            <div className="pt-4">
-              {!isCollapsed && (
-                <p className="px-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-                  Settings
-                </p>
-              )}
-              <div className="space-y-1">
-                {settingsItems.map((item) => {
-                  const Icon = item.icon;
-                  const active = isActive(item.path);
-                  
-                  return (
-                    <Link
-                      key={item.path}
-                      to={item.path}
-                      className={`flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-                        active
-                          ? "bg-primary text-primary-foreground"
-                          : "text-muted-foreground hover:text-foreground hover:bg-accent"
-                      }`}
-                      title={isCollapsed ? item.name : undefined}
-                    >
-                      <Icon className="h-4 w-4 flex-shrink-0" />
-                      {!isCollapsed && <span className="truncate">{item.name}</span>}
-                    </Link>
-                  );
-                })}
-              </div>
-            </div>
+          <div className="my-4 border-t border-border/70" />
+
+          {!isCollapsed && (
+            <p className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Account Settings</p>
+          )}
+          <nav className="space-y-1.5">
+            {settingsItems.map((item) => {
+              const Icon = item.icon;
+              const active = isActive(item.path);
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  title={isCollapsed ? item.name : undefined}
+                  className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${
+                    active
+                      ? "bg-primary/10 font-medium text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  {!isCollapsed && <span className="truncate">{item.name}</span>}
+                </Link>
+              );
+            })}
           </nav>
         </div>
 
-        {/* Sign Out */}
-        <div className="p-3 border-t border-border">
+        <div className="border-t border-border/70 p-3">
           <Button
             variant="ghost"
-            className={`w-full justify-start gap-3 text-muted-foreground hover:text-foreground ${
-              isCollapsed ? "px-3" : ""
-            }`}
-            onClick={handleSignOut}
-            title={isCollapsed ? "Sign Out" : undefined}
+            className={`w-full text-destructive hover:bg-destructive/10 hover:text-destructive ${isCollapsed ? "justify-center" : "justify-start"}`}
+            onClick={logout}
           >
-            <LogOut className="h-4 w-4 flex-shrink-0" />
-            {!isCollapsed && <span>Sign Out</span>}
+            <LogOut className="h-4 w-4" />
+            {!isCollapsed && <span className="ml-2">Sign Out</span>}
           </Button>
         </div>
       </div>
-    </div>
+    </aside>
   );
 };
 

--- a/green-tech-africa/src/components/sections/FeaturedProjects.tsx
+++ b/green-tech-africa/src/components/sections/FeaturedProjects.tsx
@@ -25,10 +25,10 @@ const FeaturedProjects = () => {
   // Show loading state
   if (isLoading) {
     return (
-      <section className="py-20 bg-background">
+      <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-6">
+          <div className="mb-14 text-center">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-4">
               Featured Projects
             </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -37,7 +37,7 @@ const FeaturedProjects = () => {
             </p>
           </div>
           
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3 mb-12">
             {[1, 2, 3].map((i) => (
               <Card key={i} className="overflow-hidden shadow-medium">
                 <div className="w-full h-48 bg-muted animate-pulse"></div>
@@ -92,12 +92,12 @@ const FeaturedProjects = () => {
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
           {projects.map((project) => (
-            <Card key={project.id} className="overflow-hidden shadow-medium hover-lift smooth-transition group">
+            <Card key={project.id} className="group overflow-hidden border-border/60 bg-card shadow-soft smooth-transition hover:-translate-y-1 hover:shadow-medium">
               <div className="relative overflow-hidden">
                 <img 
                   src={project.image} 
                   alt={project.title}
-                  className="w-full h-48 object-cover group-hover:scale-105 smooth-transition"
+                  className="h-48 w-full object-cover transition-transform duration-500 group-hover:scale-105"
                 />
                 <div className="absolute top-4 left-4">
                   <Badge className={getStatusColor(project.status)}>
@@ -143,7 +143,7 @@ const FeaturedProjects = () => {
                   )}
                 </div>
                 
-                <Button variant="ghost" className="w-full group/btn" asChild>
+                <Button variant="outline" className="w-full group/btn" asChild>
                   <Link to={`/projects/${project.id}`}>
                     View Details
                     <ArrowRight className="w-4 h-4 ml-2 group-hover/btn:translate-x-1 transition-transform" />

--- a/green-tech-africa/src/components/sections/Hero.tsx
+++ b/green-tech-africa/src/components/sections/Hero.tsx
@@ -1,85 +1,69 @@
 import { Button } from "@/components/ui/button";
-import { ArrowRight, Building, Home, Scale } from "lucide-react";
+import { ArrowRight, Building, Home, Scale, ShieldCheck, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 import heroImage from "@/assets/hero-construction.jpg";
 
+const stats = [
+  { number: "250+", label: "Projects Completed" },
+  { number: "15+", label: "Years Experience" },
+  { number: "500+", label: "Happy Clients" },
+  { number: "50+", label: "Green Buildings" },
+  { number: "1000+", label: "Acres Sold" },
+  { number: "500+", label: "Legal Cases Won" },
+];
+
 const Hero = () => {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      {/* Background Image with Overlay */}
-      <div 
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-        style={{ backgroundImage: `url(${heroImage})` }}
-      >
-        <div className="absolute inset-0 bg-gradient-to-r from-professional/90 via-professional/70 to-professional/50"></div>
+    <section className="relative flex min-h-[88vh] items-center overflow-hidden">
+      <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${heroImage})` }}>
+        <div className="absolute inset-0 bg-gradient-to-r from-professional/95 via-professional/85 to-professional/60" />
       </div>
 
-      {/* Content */}
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-        <div className="max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white mb-6 animate-fade-in">
-            Building Africa's
-            <span className="block text-gradient">
-              Sustainable Future
-            </span>
+      <div className="relative z-10 mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 lg:px-8">
+        <div className="max-w-4xl">
+          <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs text-white/90 backdrop-blur-sm">
+            <Sparkles className="h-3.5 w-3.5 text-success" />
+            Sustainable construction + trusted property investments
+          </div>
+
+          <h1 className="text-4xl font-bold leading-tight text-white md:text-6xl lg:text-7xl">
+            Build, Buy & Invest
+            <span className="block text-gradient">with Confidence in Africa</span>
           </h1>
-          
-          <p className="text-xl md:text-2xl text-white/90 mb-8 max-w-3xl mx-auto leading-relaxed animate-fade-in">
-            Leading construction and real estate development across Africa with 
-            innovative green technology and sustainable building practices.
+
+          <p className="mt-6 max-w-3xl text-lg leading-relaxed text-white/90 md:text-xl">
+            From smart homes and prime land to commercial developments, Green Tech Africa gives customers one modern platform to discover, compare, and move forward faster.
           </p>
 
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12 animate-fade-in">
-            <Button variant="hero" size="xl" asChild className="group">
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <Button variant="hero" size="xl" asChild className="group shadow-elegant">
               <Link to="/projects">
-                <Building className="w-5 h-5 mr-2" />
-                Explore Projects
-                <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />
+                <Building className="mr-2 h-5 w-5" /> Explore Projects
+                <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
               </Link>
             </Button>
-
-            <Button variant="outline" size="xl" className="bg-white/10 border-white/30 text-white hover:bg-white hover:text-professional backdrop-blur-sm" asChild>
-              <Link to="/properties">
-                <Home className="w-5 h-5 mr-2" />
-                View Properties
-              </Link>
+            <Button variant="outline" size="xl" className="border-white/30 bg-white/10 text-white hover:bg-white hover:text-professional" asChild>
+              <Link to="/properties"><Home className="mr-2 h-5 w-5" />View Properties</Link>
             </Button>
-
-            <Button variant="outline" size="xl" className="bg-white/10 border-white/30 text-white hover:bg-white hover:text-professional backdrop-blur-sm" asChild>
-              <Link to="/land">
-                <Scale className="w-5 h-5 mr-2" />
-                Land Sales & Legal
-              </Link>
+            <Button variant="outline" size="xl" className="border-white/30 bg-white/10 text-white hover:bg-white hover:text-professional" asChild>
+              <Link to="/land"><Scale className="mr-2 h-5 w-5" />Land Sales & Legal</Link>
             </Button>
           </div>
 
-          {/* Stats */}
-          <div className="grid grid-cols-2 md:grid-cols-6 gap-8 mt-16">
-            {[
-              { number: "250+", label: "Projects Completed" },
-              { number: "15+", label: "Years Experience" },
-              { number: "500+", label: "Happy Clients" },
-              { number: "50+", label: "Green Buildings" },
-              { number: "1000+", label: "Acres Sold" },
-              { number: "500+", label: "Legal Cases Won" },
-            ].map((stat, index) => (
-              <div key={index} className="text-center">
-                <div className="text-3xl md:text-4xl font-bold text-success mb-2">
-                  {stat.number}
-                </div>
-                <div className="text-white/80 text-sm md:text-base">
-                  {stat.label}
-                </div>
-              </div>
-            ))}
+          <div className="mt-8 flex flex-wrap items-center gap-4 text-sm text-white/90">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 backdrop-blur-sm"><ShieldCheck className="h-4 w-4 text-success" />Verified listings</div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 backdrop-blur-sm"><ShieldCheck className="h-4 w-4 text-success" />Transparent documentation</div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 backdrop-blur-sm"><ShieldCheck className="h-4 w-4 text-success" />Dedicated support</div>
           </div>
         </div>
-      </div>
 
-      {/* Scroll Indicator */}
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <div className="w-6 h-10 border-2 border-white/50 rounded-full flex justify-center">
-          <div className="w-1 h-3 bg-white/70 rounded-full mt-2 animate-pulse"></div>
+        <div className="mt-14 grid grid-cols-2 gap-4 rounded-2xl border border-white/15 bg-white/10 p-5 backdrop-blur-md md:grid-cols-6">
+          {stats.map((stat) => (
+            <div key={stat.label} className="text-center">
+              <div className="text-2xl font-bold text-success md:text-3xl">{stat.number}</div>
+              <div className="mt-1 text-xs text-white/80 md:text-sm">{stat.label}</div>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/green-tech-africa/src/components/sections/ServicesOverview.tsx
+++ b/green-tech-africa/src/components/sections/ServicesOverview.tsx
@@ -1,14 +1,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { 
-  Building2, 
-  Home, 
-  TreePine, 
+import {
+  ArrowRight,
+  Building2,
+  Home,
+  MapPin,
   Scale,
-  Wrench, 
-  MapPin, 
   Shield,
-  ArrowRight 
+  TreePine,
+  Wrench,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -17,68 +17,66 @@ const ServicesOverview = () => {
     {
       icon: Building2,
       title: "Construction Services",
-      description: "Residential, commercial, and infrastructure development with cutting-edge sustainable practices.",
+      description:
+        "Residential, commercial, and infrastructure development with modern project delivery.",
       features: ["Residential Buildings", "Commercial Complexes", "Infrastructure Development"],
-      color: "text-primary"
+      color: "text-primary",
     },
     {
       icon: Home,
-      title: "Real Estate Services", 
-      description: "Complete property solutions from buying and selling to comprehensive management services.",
+      title: "Real Estate Services",
+      description:
+        "Complete property solutions from discovery and sales to long-term management.",
       features: ["Property Sales", "Leasing Services", "Property Management"],
-      color: "text-success"
+      color: "text-success",
     },
     {
       icon: TreePine,
       title: "Green Building Solutions",
-      description: "Eco-friendly construction methods and renewable energy integration for sustainable development.",
+      description:
+        "Eco-friendly construction and renewable integration for efficient, future-ready assets.",
       features: ["Solar Installation", "Green Certification", "Energy Efficiency"],
-      color: "text-primary-light"
+      color: "text-primary-light",
     },
     {
       icon: Scale,
       title: "Land & Legal Services",
-      description: "Comprehensive land sales and legal support for all your property and land-related needs across Africa.",
+      description:
+        "Comprehensive land sales and legal support for safer transactions across Africa.",
       features: ["Land Sales", "Legal Consultation", "Title Registration"],
-      color: "text-accent"
-    }
+      color: "text-accent",
+    },
   ];
 
   return (
-    <section className="py-20 bg-muted/30">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-6">
-            Our Services
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-            Comprehensive construction and real estate solutions designed to build 
-            Africa's sustainable future with innovative green technology.
+    <section className="py-20">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-14 max-w-3xl">
+          <p className="mb-3 text-sm font-medium uppercase tracking-wide text-primary">What we offer</p>
+          <h2 className="text-3xl font-bold text-foreground md:text-5xl">Modern services for construction and real estate growth</h2>
+          <p className="mt-4 text-lg text-muted-foreground">
+            We blend technology, market insight, and on-ground expertise to simplify major decisions for customers.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
-          {services.map((service, index) => {
-            const IconComponent = service.icon;
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {services.map((service) => {
+            const Icon = service.icon;
             return (
-              <Card key={index} className="shadow-medium hover-lift smooth-transition h-full">
-                <CardHeader className="text-center pb-4">
-                  <div className={`w-16 h-16 mx-auto rounded-2xl bg-gradient-to-br from-accent to-accent/50 flex items-center justify-center mb-4`}>
-                    <IconComponent className={`w-8 h-8 ${service.color}`} />
+              <Card key={service.title} className="h-full border-border/60 bg-background/90 shadow-soft smooth-transition hover:-translate-y-1 hover:shadow-medium">
+                <CardHeader className="pb-3">
+                  <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-accent/70">
+                    <Icon className={`h-6 w-6 ${service.color}`} />
                   </div>
-                  <CardTitle className="text-xl font-semibold mb-2">
-                    {service.title}
-                  </CardTitle>
+                  <CardTitle className="text-lg">{service.title}</CardTitle>
                 </CardHeader>
-                <CardContent className="pt-0">
-                  <p className="text-muted-foreground mb-6 text-center">
-                    {service.description}
-                  </p>
-                  <ul className="space-y-2 mb-6">
-                    {service.features.map((feature, featureIndex) => (
-                      <li key={featureIndex} className="flex items-center text-sm">
-                        <Shield className="w-4 h-4 text-success mr-2 flex-shrink-0" />
-                        {feature}
+                <CardContent>
+                  <p className="mb-4 text-sm text-muted-foreground">{service.description}</p>
+                  <ul className="space-y-2">
+                    {service.features.map((feature) => (
+                      <li key={feature} className="flex items-center gap-2 text-sm">
+                        <Shield className="h-4 w-4 text-success" />
+                        <span>{feature}</span>
                       </li>
                     ))}
                   </ul>
@@ -88,31 +86,29 @@ const ServicesOverview = () => {
           })}
         </div>
 
-        {/* Additional Services Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
+        <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           {[
             { icon: Wrench, title: "Maintenance", desc: "Ongoing property maintenance" },
             { icon: MapPin, title: "Site Planning", desc: "Strategic location analysis" },
             { icon: Shield, title: "Quality Assurance", desc: "Rigorous quality control" },
             { icon: TreePine, title: "Sustainability", desc: "Environmental compliance" },
-          ].map((item, index) => {
-            const IconComponent = item.icon;
+          ].map((item) => {
+            const Icon = item.icon;
             return (
-              <div key={index} className="text-center p-6 rounded-lg bg-background shadow-soft hover-lift smooth-transition">
-                <IconComponent className="w-10 h-10 text-primary mx-auto mb-4" />
-                <h4 className="font-semibold mb-2">{item.title}</h4>
-                <p className="text-sm text-muted-foreground">{item.desc}</p>
+              <div key={item.title} className="rounded-xl border border-border/70 bg-card p-5 text-center shadow-soft">
+                <Icon className="mx-auto mb-3 h-8 w-8 text-primary" />
+                <h4 className="font-semibold">{item.title}</h4>
+                <p className="mt-1 text-sm text-muted-foreground">{item.desc}</p>
               </div>
             );
           })}
         </div>
 
-        {/* CTA */}
-        <div className="text-center">
+        <div className="mt-10 text-center">
           <Button variant="hero" size="lg" asChild className="group">
             <Link to="/services">
               View All Services
-              <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />
+              <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
             </Link>
           </Button>
         </div>

--- a/green-tech-africa/src/components/sections/Testimonials.tsx
+++ b/green-tech-africa/src/components/sections/Testimonials.tsx
@@ -39,9 +39,9 @@ const Testimonials = () => {
   ];
 
   return (
-    <section className="py-20 bg-accent/20">
+    <section className="py-20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
+        <div className="text-center mb-14">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-6">
             What Our Clients Say
           </h2>
@@ -54,7 +54,7 @@ const Testimonials = () => {
         {/* Testimonials Grid */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
           {testimonials.map((testimonial, index) => (
-            <Card key={index} className="shadow-medium hover-lift smooth-transition">
+            <Card key={index} className="border-border/70 shadow-soft smooth-transition hover:-translate-y-1 hover:shadow-medium">
               <CardContent className="p-6">
                 <div className="flex items-center mb-4">
                   <Quote className="w-8 h-8 text-primary/30 mr-2" />
@@ -99,7 +99,7 @@ const Testimonials = () => {
             {clients.map((client, index) => (
               <div 
                 key={index} 
-                className="bg-background rounded-lg p-4 shadow-soft hover-lift smooth-transition"
+                className="rounded-lg border border-border/70 bg-background p-4 shadow-soft smooth-transition hover:-translate-y-0.5"
               >
                 <div className="text-center text-sm font-medium text-muted-foreground">
                   {client}

--- a/green-tech-africa/src/pages/account/Appointments.tsx
+++ b/green-tech-africa/src/pages/account/Appointments.tsx
@@ -1,5 +1,6 @@
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 import { Button } from "@/components/ui/button";
 import { Calendar as CalendarIcon } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -30,18 +31,15 @@ const Appointments = () => {
 
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <CalendarIcon className="w-6 h-6" />
-            <h1 className="text-2xl md:text-3xl font-bold">Appointments</h1>
-          </div>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="Appointments"
+        description="Manage upcoming property viewings and review past appointments."
+        icon={<CalendarIcon className="h-3.5 w-3.5" />}
+      />
 
       <section className="py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <Card className="shadow-medium">
+          <Card className="border-border/70 shadow-soft">
             <CardHeader><CardTitle>Upcoming</CardTitle></CardHeader>
             <CardContent className="space-y-3">
               {isLoading && (
@@ -69,7 +67,7 @@ const Appointments = () => {
             </CardContent>
           </Card>
 
-          <Card className="shadow-medium">
+          <Card className="border-border/70 shadow-soft">
             <CardHeader><CardTitle>Past</CardTitle></CardHeader>
             <CardContent className="space-y-3">
               {!isLoading && !error && past.map((a) => (

--- a/green-tech-africa/src/pages/account/Dashboard.tsx
+++ b/green-tech-africa/src/pages/account/Dashboard.tsx
@@ -1,29 +1,38 @@
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { ProjectStatusCard } from "@/components/dashboard/ProjectStatusCard";
 import { ActivityFeed } from "@/components/dashboard/ActivityFeed";
-import { NotificationCenter, type Notification, type NotificationPreferences } from "@/components/dashboard/NotificationCenter";
+import {
+  NotificationCenter,
+  type Notification,
+  type NotificationPreferences,
+} from "@/components/dashboard/NotificationCenter";
 import { SavedSearchesWidget } from "@/components/dashboard/SavedSearchesWidget";
-import { 
+import {
+  AlertTriangle,
+  Bell,
+  Building,
   ClipboardList,
   FileSpreadsheet,
-  Calendar,
-  TrendingUp,
-  Users,
-  Building,
-  CheckCircle2,
   Loader2,
-  AlertTriangle
+  MessageSquare,
+  Sparkles,
+  Users,
 } from "lucide-react";
-import { Link, useNavigate } from "react-router-dom";
-import { api, dashboardApi, type CustomerDashboardMetrics, type CustomerNotifications } from "@/lib/api";
-import { getSavedSearches, toggleAlerts, deleteSavedSearch, type SavedSearch } from "@/lib/savedSearches";
+import { api, dashboardApi } from "@/lib/api";
+import {
+  deleteSavedSearch,
+  getSavedSearches,
+  toggleAlerts,
+  type SavedSearch,
+} from "@/lib/savedSearches";
 import type { ProjectSummary } from "@/types/project";
-import { useEffect, useState } from "react";
 
 const Dashboard = () => {
   const navigate = useNavigate();
@@ -31,17 +40,20 @@ const Dashboard = () => {
   const [savedSearches, setSavedSearches] = useState<SavedSearch[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(true);
 
-  // Dashboard data from API
-  const { data: dashboardData, isLoading: dashboardLoading, error: dashboardError } = useQuery({
-    queryKey: ['customer-dashboard'],
+  const {
+    data: dashboardData,
+    isLoading: dashboardLoading,
+    error: dashboardError,
+  } = useQuery({
+    queryKey: ["customer-dashboard"],
     queryFn: dashboardApi.getCustomerDashboard,
-    refetchInterval: 2 * 60 * 1000, // Refetch every 2 minutes
+    refetchInterval: 2 * 60 * 1000,
   });
 
   const { data: notificationData, isLoading: notificationsLoading } = useQuery({
-    queryKey: ['customer-notifications'],
+    queryKey: ["customer-notifications"],
     queryFn: dashboardApi.getCustomerNotifications,
-    refetchInterval: 30 * 1000, // Refetch every 30 seconds
+    refetchInterval: 30 * 1000,
   });
 
   useEffect(() => {
@@ -50,62 +62,48 @@ const Dashboard = () => {
 
   useEffect(() => {
     let cancelled = false;
-    async function load() {
+
+    const loadProjects = async () => {
       try {
         setProjectsLoading(true);
         const data = await api.get<ProjectSummary[]>("/api/construction/projects/");
-        if (!cancelled) {
-          setProjects(Array.isArray(data) ? data : []);
-        }
-      } catch (err) {
-        console.error("Failed to load projects:", err);
-        if (!cancelled) {
-          setProjects([]);
-        }
+        if (!cancelled) setProjects(Array.isArray(data) ? data : []);
+      } catch (error) {
+        console.error("Failed to load projects:", error);
+        if (!cancelled) setProjects([]);
       } finally {
-        if (!cancelled) {
-          setProjectsLoading(false);
-        }
+        if (!cancelled) setProjectsLoading(false);
       }
-    }
-    load();
+    };
+
+    loadProjects();
     return () => {
       cancelled = true;
     };
   }, []);
 
-  const handleToggleAlerts = (id: string) => {
-    setSavedSearches(toggleAlerts(id));
-  };
-
-  const handleDeleteSearch = (id: string) => {
-    setSavedSearches(deleteSavedSearch(id));
-  };
-
   const handleApplySearch = (search: SavedSearch) => {
     const params = new URLSearchParams();
-    const f = search.filters as any;
-    if (f.q) params.set("q", f.q);
-    if (f.type) params.set("type", f.type);
-    if (f.location) params.set("location", f.location);
+    const filters = search.filters as Record<string, string | undefined>;
+    if (filters.q) params.set("q", filters.q);
+    if (filters.type) params.set("type", filters.type);
+    if (filters.location) params.set("location", filters.location);
     navigate(`/properties?${params.toString()}`);
   };
 
   const handleMarkAsRead = async (id: string) => {
     try {
       await dashboardApi.markNotificationAsRead(id);
-      // Refetch notifications to update UI
     } catch (error) {
-      console.error('Failed to mark notification as read:', error);
+      console.error("Failed to mark notification as read:", error);
     }
   };
 
   const handleMarkAllAsRead = async () => {
     try {
       await dashboardApi.markAllNotificationsAsRead();
-      // Refetch notifications to update UI
     } catch (error) {
-      console.error('Failed to mark all notifications as read:', error);
+      console.error("Failed to mark all notifications as read:", error);
     }
   };
 
@@ -120,15 +118,15 @@ const Dashboard = () => {
         payment_reminders: preferences.paymentReminders,
         marketing_emails: preferences.marketingEmails,
       });
-      // Refetch notifications to update UI
     } catch (error) {
-      console.error('Failed to update preferences:', error);
+      console.error("Failed to update preferences:", error);
     }
   };
 
-  const activeProjects = Array.isArray(projects) ? projects.filter(p => 
-    p.status.toLowerCase() === 'in_progress' || p.status.toLowerCase() === 'planning'
-  ) : [];
+  const activeProjects = projects.filter(
+    (project) =>
+      project.status.toLowerCase() === "in_progress" || project.status.toLowerCase() === "planning",
+  );
 
   const unreadNotifications = notificationData?.unread_count || 0;
 
@@ -156,33 +154,18 @@ const Dashboard = () => {
   if (dashboardError) {
     return (
       <Layout>
-        <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex flex-col gap-2">
-              <h1 className="text-3xl md:text-4xl font-bold">Welcome back</h1>
-              <p className="text-muted-foreground">Your projects, quotes, and requests at a glance.</p>
-            </div>
-          </div>
-        </section>
-        
-        <section className="py-8">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <Card>
-              <CardContent className="pt-6">
-                <div className="text-center text-red-600">
-                  <AlertTriangle className="h-8 w-8 mx-auto mb-2" />
-                  <p className="font-semibold">Failed to load dashboard</p>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {dashboardError instanceof Error ? dashboardError.message : 'Please try again later'}
-                  </p>
-                  <Button 
-                    variant="outline" 
-                    className="mt-4"
-                    onClick={() => window.location.reload()}
-                  >
-                    Retry
-                  </Button>
-                </div>
+        <section className="py-10">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <Card className="border-destructive/30">
+              <CardContent className="p-8 text-center">
+                <AlertTriangle className="mx-auto mb-3 h-8 w-8 text-destructive" />
+                <p className="text-lg font-semibold">Failed to load dashboard</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {dashboardError instanceof Error ? dashboardError.message : "Please try again later."}
+                </p>
+                <Button variant="outline" className="mt-4" onClick={() => window.location.reload()}>
+                  Retry
+                </Button>
               </CardContent>
             </Card>
           </div>
@@ -193,103 +176,90 @@ const Dashboard = () => {
 
   return (
     <Layout>
-      {/* Hero */}
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-3xl md:text-4xl font-bold">Welcome back</h1>
-            <p className="text-muted-foreground">Your projects, quotes, and requests at a glance.</p>
+      <section className="border-b border-border/70 bg-gradient-to-b from-accent/30 to-background py-8">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                <Sparkles className="h-3.5 w-3.5" /> Customer Workspace
+              </div>
+              <h1 className="text-2xl font-bold md:text-4xl">Welcome back</h1>
+              <p className="mt-1 text-muted-foreground">Track projects, quotes, requests and communication in one place.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" asChild>
+                <Link to="/account/requests/new">
+                  <ClipboardList className="mr-2 h-4 w-4" /> New Request
+                </Link>
+              </Button>
+              <Button variant="hero" asChild>
+                <Link to="/account/messages">
+                  <MessageSquare className="mr-2 h-4 w-4" /> Open Messages
+                </Link>
+              </Button>
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {[
+              {
+                label: "Active Projects",
+                value: dashboardData?.projects.active ?? 0,
+                icon: Building,
+                loading: dashboardLoading,
+              },
+              {
+                label: "Total Leads",
+                value: dashboardData?.leads.total ?? 0,
+                icon: Users,
+                loading: dashboardLoading,
+              },
+              {
+                label: "Pending Quotes",
+                value: dashboardData?.quotes.pending ?? 0,
+                icon: FileSpreadsheet,
+                loading: dashboardLoading,
+              },
+              {
+                label: "Unread Notifications",
+                value: unreadNotifications,
+                icon: Bell,
+                loading: notificationsLoading,
+              },
+            ].map((item) => {
+              const Icon = item.icon;
+              return (
+                <Card key={item.label} className="border-border/70 bg-card/80 shadow-soft">
+                  <CardContent className="p-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">{item.label}</p>
+                        <div className="mt-1 text-2xl font-bold">
+                          {item.loading ? <Loader2 className="h-5 w-5 animate-spin" /> : item.value}
+                        </div>
+                      </div>
+                      <div className="rounded-lg bg-primary/10 p-2">
+                        <Icon className="h-5 w-5 text-primary" />
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
           </div>
         </div>
       </section>
 
-      {/* Content */}
       <section className="py-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Quick stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-            <Card className="shadow-soft hover:shadow-medium smooth-transition">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-sm text-muted-foreground">Active Projects</div>
-                    {dashboardLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span className="text-sm">Loading...</span>
-                      </div>
-                    ) : (
-                      <div className="text-2xl font-bold">{dashboardData?.projects.active || 0}</div>
-                    )}
-                  </div>
-                  <Building className="w-8 h-8 text-primary/20" />
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="shadow-soft hover:shadow-medium smooth-transition">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-sm text-muted-foreground">Total Leads</div>
-                    {dashboardLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span className="text-sm">Loading...</span>
-                      </div>
-                    ) : (
-                      <div className="text-2xl font-bold">{dashboardData?.leads.total || 0}</div>
-                    )}
-                  </div>
-                  <Users className="w-8 h-8 text-primary/20" />
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="shadow-soft hover:shadow-medium smooth-transition">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-sm text-muted-foreground">Pending Quotes</div>
-                    {dashboardLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span className="text-sm">Loading...</span>
-                      </div>
-                    ) : (
-                      <div className="text-2xl font-bold">{dashboardData?.quotes.pending || 0}</div>
-                    )}
-                  </div>
-                  <FileSpreadsheet className="w-8 h-8 text-primary/20" />
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="shadow-soft hover:shadow-medium smooth-transition">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-sm text-muted-foreground">Notifications</div>
-                    {notificationsLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span className="text-sm">Loading...</span>
-                      </div>
-                    ) : (
-                      <div className="text-2xl font-bold">{unreadNotifications}</div>
-                    )}
-                  </div>
-                  <Calendar className="w-8 h-8 text-primary/20" />
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <Tabs defaultValue="overview" className="space-y-6">
-            <TabsList>
+            <TabsList className="grid w-full grid-cols-3 md:w-auto">
               <TabsTrigger value="overview">Overview</TabsTrigger>
-              <TabsTrigger value="activity">Activity Feed</TabsTrigger>
-              <TabsTrigger value="notifications">
+              <TabsTrigger value="activity">Activity</TabsTrigger>
+              <TabsTrigger value="notifications" className="relative">
                 Notifications
                 {unreadNotifications > 0 && (
-                  <Badge variant="destructive" className="ml-2 h-5 w-5 p-0 text-xs">
+                  <Badge variant="destructive" className="ml-2 h-5 min-w-5 px-1 text-xs">
                     {unreadNotifications}
                   </Badge>
                 )}
@@ -297,96 +267,77 @@ const Dashboard = () => {
             </TabsList>
 
             <TabsContent value="overview">
-              <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-                {/* Main content - 2 columns */}
-                <div className="xl:col-span-2 space-y-6">
-                  {/* Active Projects */}
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <h2 className="text-xl font-semibold">Active Projects</h2>
-                      <Button variant="outline" size="sm" asChild>
-                        <Link to="/account/projects">View all</Link>
-                      </Button>
-                    </div>
-                    {projectsLoading ? (
-                      <Card>
-                        <CardContent className="p-6">
-                          <div className="flex items-center gap-2">
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            <span className="text-sm text-muted-foreground">Loading projects...</span>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    ) : activeProjects.length === 0 ? (
-                      <Card>
-                        <CardContent className="p-6 text-sm text-muted-foreground text-center">
-                          <p>No active projects yet.</p>
-                          <Button variant="hero" className="mt-4" asChild>
-                            <Link to="/plans">Browse Plans to Request</Link>
-                          </Button>
-                        </CardContent>
-                      </Card>
-                    ) : (
-                      <div className="space-y-4">
-                        {activeProjects.slice(0, 3).map((project) => (
-                          <ProjectStatusCard key={project.id} project={project} />
-                        ))}
+              <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+                <div className="space-y-6 xl:col-span-2">
+                  <Card className="border-border/70 shadow-soft">
+                    <CardContent className="p-5">
+                      <div className="mb-4 flex items-center justify-between">
+                        <h2 className="text-lg font-semibold">Active Projects</h2>
+                        <Button variant="outline" size="sm" asChild>
+                          <Link to="/account/my-projects">View all</Link>
+                        </Button>
                       </div>
-                    )}
-                  </div>
 
-                  {/* Recent Activity */}
-                  <div className="space-y-4">
-                    <h2 className="text-xl font-semibold">Recent Activity</h2>
-                    {dashboardLoading ? (
-                      <Card>
-                        <CardContent className="p-6">
-                          <div className="flex items-center gap-2">
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            <span className="text-sm text-muted-foreground">Loading activities...</span>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    ) : (
-                      <ActivityFeed 
-                        activities={dashboardData?.recent_activities || []} 
-                        maxItems={5} 
-                      />
-                    )}
-                  </div>
+                      {projectsLoading ? (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Loader2 className="h-4 w-4 animate-spin" /> Loading projects...
+                        </div>
+                      ) : activeProjects.length === 0 ? (
+                        <div className="rounded-xl border border-dashed p-6 text-center">
+                          <p className="text-sm text-muted-foreground">No active projects yet.</p>
+                          <Button variant="hero" className="mt-4" asChild>
+                            <Link to="/plans">Browse plans to request build</Link>
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="space-y-4">
+                          {activeProjects.slice(0, 3).map((project) => (
+                            <ProjectStatusCard key={project.id} project={project} />
+                          ))}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+
+                  <Card className="border-border/70 shadow-soft">
+                    <CardContent className="p-5">
+                      <h2 className="mb-4 text-lg font-semibold">Recent Activity</h2>
+                      {dashboardLoading ? (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Loader2 className="h-4 w-4 animate-spin" /> Loading activity...
+                        </div>
+                      ) : (
+                        <ActivityFeed activities={dashboardData?.recent_activities || []} maxItems={5} />
+                      )}
+                    </CardContent>
+                  </Card>
                 </div>
 
-                {/* Sidebar - 1 column */}
                 <div className="space-y-6">
-                  {/* Saved Searches */}
                   <SavedSearchesWidget
                     searches={savedSearches}
-                    onToggleAlerts={handleToggleAlerts}
-                    onDelete={handleDeleteSearch}
+                    onToggleAlerts={(id) => setSavedSearches(toggleAlerts(id))}
+                    onDelete={(id) => setSavedSearches(deleteSavedSearch(id))}
                     onApply={handleApplySearch}
                     maxItems={3}
                   />
 
-                  {/* Quick Actions */}
-                  <Card className="shadow-medium">
-                    <CardContent className="p-4 space-y-3">
-                      <h3 className="font-semibold text-sm mb-3">Quick Actions</h3>
+                  <Card className="border-border/70 shadow-soft">
+                    <CardContent className="space-y-3 p-5">
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Quick Actions</h3>
                       <Button variant="outline" className="w-full justify-start" asChild>
-                        <Link to="/plans">
-                          <ClipboardList className="w-4 h-4 mr-2" />
-                          Request New Build
+                        <Link to="/account/requests/new">
+                          <ClipboardList className="mr-2 h-4 w-4" /> Request New Build
                         </Link>
                       </Button>
                       <Button variant="outline" className="w-full justify-start" asChild>
-                        <Link to="/properties">
-                          <FileSpreadsheet className="w-4 h-4 mr-2" />
-                          Browse Properties
+                        <Link to="/account/properties">
+                          <Building className="mr-2 h-4 w-4" /> Browse Properties
                         </Link>
                       </Button>
                       <Button variant="outline" className="w-full justify-start" asChild>
                         <Link to="/account/messages">
-                          <Calendar className="w-4 h-4 mr-2" />
-                          View Messages
+                          <MessageSquare className="mr-2 h-4 w-4" /> View Messages
                         </Link>
                       </Button>
                     </CardContent>
@@ -396,33 +347,26 @@ const Dashboard = () => {
             </TabsContent>
 
             <TabsContent value="activity">
-              <div className="max-w-4xl mx-auto">
-                {dashboardLoading ? (
-                  <Card>
-                    <CardContent className="p-6">
-                      <div className="flex items-center justify-center">
-                        <Loader2 className="h-6 w-6 animate-spin mr-2" />
-                        <span className="text-muted-foreground">Loading activities...</span>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  <ActivityFeed 
-                    activities={dashboardData?.recent_activities || []} 
-                    maxItems={20} 
-                  />
-                )}
-              </div>
+              <Card className="mx-auto max-w-5xl border-border/70 shadow-soft">
+                <CardContent className="p-5">
+                  {dashboardLoading ? (
+                    <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                      <Loader2 className="h-5 w-5 animate-spin" /> Loading activities...
+                    </div>
+                  ) : (
+                    <ActivityFeed activities={dashboardData?.recent_activities || []} maxItems={20} />
+                  )}
+                </CardContent>
+              </Card>
             </TabsContent>
 
             <TabsContent value="notifications">
-              <div className="max-w-4xl mx-auto">
+              <div className="mx-auto max-w-5xl">
                 {notificationsLoading ? (
-                  <Card>
+                  <Card className="border-border/70 shadow-soft">
                     <CardContent className="p-6">
-                      <div className="flex items-center justify-center">
-                        <Loader2 className="h-6 w-6 animate-spin mr-2" />
-                        <span className="text-muted-foreground">Loading notifications...</span>
+                      <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                        <Loader2 className="h-5 w-5 animate-spin" /> Loading notifications...
                       </div>
                     </CardContent>
                   </Card>
@@ -435,11 +379,8 @@ const Dashboard = () => {
                     onUpdatePreferences={handleUpdatePreferences}
                   />
                 ) : (
-                  <Card>
-                    <CardContent className="p-6 text-center text-muted-foreground">
-                      <Calendar className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                      <p>No notifications available</p>
-                    </CardContent>
+                  <Card className="border-border/70 shadow-soft">
+                    <CardContent className="p-6 text-center text-muted-foreground">No notifications available.</CardContent>
                   </Card>
                 )}
               </div>
@@ -452,4 +393,3 @@ const Dashboard = () => {
 };
 
 export default Dashboard;
-

--- a/green-tech-africa/src/pages/account/Documents.tsx
+++ b/green-tech-africa/src/pages/account/Documents.tsx
@@ -1,7 +1,8 @@
 import Layout from "@/components/layout/Layout";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { FileText } from "lucide-react";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 
 const DOCS = [
   { id: "DOC-1001", name: "Quote QUO-551.pdf", type: "Quote", uploadedAt: "2025-03-09" },
@@ -11,15 +12,15 @@ const DOCS = [
 const Documents = () => {
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-2xl md:text-3xl font-bold">Documents</h1>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="Documents"
+        description="Access quote files, permits, and supporting documents in one place."
+        icon={<FileText className="h-3.5 w-3.5" />}
+      />
       <section className="py-8">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3">
           {DOCS.map((d) => (
-            <Card key={d.id} className="shadow-soft">
+            <Card key={d.id} className="border-border/70 shadow-soft">
               <CardContent className="p-4 flex items-center justify-between text-sm">
                 <div className="flex items-center gap-3">
                   <FileText className="w-4 h-4" />

--- a/green-tech-africa/src/pages/account/Favorites.tsx
+++ b/green-tech-africa/src/pages/account/Favorites.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { PROPERTIES } from "@/mocks/properties";
 import { getFavorites, toggleFavorite } from "@/lib/favorites";
 import { Heart } from "lucide-react";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
@@ -18,15 +19,15 @@ const Favorites = () => {
 
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-2xl md:text-3xl font-bold">Saved Properties</h1>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="Saved Properties"
+        description="Quickly revisit listings you bookmarked and continue your purchase journey."
+        icon={<Heart className="h-3.5 w-3.5" />}
+      />
       <section className="py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {items.map((p) => (
-            <Card key={p.id} className="overflow-hidden shadow-medium">
+            <Card key={p.id} className="overflow-hidden border-border/70 shadow-soft smooth-transition hover:-translate-y-1 hover:shadow-medium">
               <div className="relative">
                 <img src={p.image} alt={p.title} className="w-full h-44 object-cover" />
                 <div className="absolute top-4 left-4"><Badge variant="secondary">{p.type}</Badge></div>

--- a/green-tech-africa/src/pages/account/Messages.tsx
+++ b/green-tech-africa/src/pages/account/Messages.tsx
@@ -1,8 +1,9 @@
 import Layout from "@/components/layout/Layout";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { MessageCircle } from "lucide-react";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 import { Link } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
@@ -93,17 +94,16 @@ const Messages = () => {
 
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <MessageCircle className="w-6 h-6" />
-            <h1 className="text-2xl md:text-3xl font-bold">Messages</h1>
-          </div>
-          <div className="w-64">
+      <AccountPageHeader
+        title="Messages"
+        description="Stay in sync with agents and support teams across your quote threads."
+        icon={<MessageCircle className="h-3.5 w-3.5" />}
+        actions={
+          <div className="w-full sm:w-72">
             <Input placeholder="Search threads..." value={search} onChange={(e) => setSearch(e.target.value)} />
           </div>
-        </div>
-      </section>
+        }
+      />
 
       <section className="py-8">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3">
@@ -118,7 +118,7 @@ const Messages = () => {
             </Card>
           )}
           {filtered.map((t) => (
-            <Card key={t.id} className="shadow-soft hover:shadow-medium smooth-transition">
+            <Card key={t.id} className="border-border/70 shadow-soft smooth-transition hover:-translate-y-0.5 hover:shadow-medium">
               <CardContent className="p-4 flex items-center justify-between">
                 <div>
                   <div className="font-medium">{t.title}</div>

--- a/green-tech-africa/src/pages/account/MyProjects.tsx
+++ b/green-tech-africa/src/pages/account/MyProjects.tsx
@@ -1,9 +1,10 @@
 import Layout from "@/components/layout/Layout";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { Building2, MapPin, Calendar, Loader2, TrendingUp, AlertCircle } from "lucide-react";
+import { Building2, Calendar, Loader2, AlertCircle } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
@@ -14,13 +15,10 @@ interface Project {
   status: string;
   current_phase: string;
   progress_percentage: number;
-  property: any;
-  planned_start_date?: string;
   planned_end_date?: string;
   estimated_budget: string;
   currency: string;
   is_behind_schedule: boolean;
-  created_at: string;
 }
 
 const statusConfig = {
@@ -35,8 +33,8 @@ const statusConfig = {
 
 const MyProjects = () => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ['my-projects'],
-    queryFn: () => api.get<{ results: Project[] }>('/api/construction/projects/').then(res => res.results || []),
+    queryKey: ["my-projects"],
+    queryFn: () => api.get<{ results: Project[] }>("/api/construction/projects/").then((res) => res.results || []),
   });
 
   const projects = data || [];
@@ -44,7 +42,7 @@ const MyProjects = () => {
   if (isLoading) {
     return (
       <Layout>
-        <div className="flex items-center justify-center min-h-96">
+        <div className="flex min-h-96 items-center justify-center">
           <Loader2 className="h-8 w-8 animate-spin" />
           <span className="ml-2">Loading projects...</span>
         </div>
@@ -55,7 +53,7 @@ const MyProjects = () => {
   if (error) {
     return (
       <Layout>
-        <div className="flex items-center justify-center min-h-96">
+        <div className="flex min-h-96 items-center justify-center">
           <div className="text-center">
             <h2 className="text-lg font-semibold text-red-600">Error loading projects</h2>
             <p className="text-muted-foreground">Please try again later.</p>
@@ -68,32 +66,27 @@ const MyProjects = () => {
   return (
     <Layout>
       <div className="min-h-screen bg-background">
-        <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex items-center justify-between">
-              <div>
-                <h1 className="text-3xl font-bold mb-2">My Projects</h1>
-                <p className="text-muted-foreground">
-                  Track your construction projects and their progress
-                </p>
-              </div>
-              <Button variant="outline" asChild>
-                <Link to="/account/projects">Browse Project Catalog</Link>
-              </Button>
-            </div>
-          </div>
-        </section>
+        <AccountPageHeader
+          title="My Projects"
+          description="Track your construction projects, progress milestones, and due dates."
+          icon={<Building2 className="h-3.5 w-3.5" />}
+          actions={
+            <Button variant="outline" asChild>
+              <Link to="/account/projects">Browse Project Catalog</Link>
+            </Button>
+          }
+        />
 
         <section className="py-8">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             {projects.length === 0 ? (
-              <div className="text-center py-12">
-                <Building2 className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
-                <h3 className="text-xl font-semibold mb-2">No Projects Yet</h3>
-                <p className="text-muted-foreground mb-6">
-                  You don't have any active projects. Browse our plans to get started.
+              <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 py-12 text-center">
+                <Building2 className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
+                <h3 className="mb-2 text-xl font-semibold">No Projects Yet</h3>
+                <p className="mb-6 text-muted-foreground">
+                  You don't have active projects yet. Browse plans to get started.
                 </p>
-                <div className="flex gap-3 justify-center">
+                <div className="flex justify-center gap-3">
                   <Button asChild>
                     <Link to="/plans">Browse Plans</Link>
                   </Button>
@@ -103,49 +96,44 @@ const MyProjects = () => {
                 </div>
               </div>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
                 {projects.map((project) => {
                   const statusInfo = statusConfig[project.status as keyof typeof statusConfig] || statusConfig.DRAFT;
-                  
+
                   return (
-                    <Card key={project.id} className="hover:shadow-lg smooth-transition">
+                    <Card key={project.id} className="border-border/70 shadow-soft smooth-transition hover:-translate-y-0.5 hover:shadow-medium">
                       <CardHeader>
-                        <div className="flex items-start justify-between mb-2">
-                          <CardTitle className="text-lg line-clamp-2">{project.title}</CardTitle>
+                        <div className="mb-2 flex items-start justify-between">
+                          <CardTitle className="line-clamp-2 text-lg">{project.title}</CardTitle>
                           <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
                         </div>
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <Building2 className="w-4 h-4" />
-                          <span>{project.current_phase?.replace(/_/g, ' ')}</span>
+                          <Building2 className="h-4 w-4" />
+                          <span>{project.current_phase?.replace(/_/g, " ")}</span>
                         </div>
                       </CardHeader>
                       <CardContent className="space-y-4">
-                        {/* Progress */}
                         <div>
-                          <div className="flex items-center justify-between mb-2">
+                          <div className="mb-2 flex items-center justify-between">
                             <span className="text-sm font-medium">Progress</span>
                             <span className="text-sm font-semibold">{project.progress_percentage}%</span>
                           </div>
                           <Progress value={project.progress_percentage} className="h-2" />
                           {project.is_behind_schedule && (
-                            <div className="flex items-center gap-1 mt-2 text-xs text-orange-600">
-                              <AlertCircle className="w-3 h-3" />
+                            <div className="mt-2 flex items-center gap-1 text-xs text-orange-600">
+                              <AlertCircle className="h-3 w-3" />
                               <span>Behind schedule</span>
                             </div>
                           )}
                         </div>
 
-                        {/* Timeline */}
                         {project.planned_end_date && (
-                          <div className="flex items-center gap-2 text-sm">
-                            <Calendar className="w-4 h-4 text-muted-foreground" />
-                            <span className="text-muted-foreground">
-                              Due: {new Date(project.planned_end_date).toLocaleDateString()}
-                            </span>
+                          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <Calendar className="h-4 w-4" />
+                            <span>Due: {new Date(project.planned_end_date).toLocaleDateString()}</span>
                           </div>
                         )}
 
-                        {/* Budget */}
                         <div className="text-sm">
                           <span className="text-muted-foreground">Budget: </span>
                           <span className="font-semibold">
@@ -154,9 +142,7 @@ const MyProjects = () => {
                         </div>
 
                         <Button className="w-full" asChild>
-                          <Link to={`/account/my-projects/${project.id}`}>
-                            View Details
-                          </Link>
+                          <Link to={`/account/my-projects/${project.id}`}>View Details</Link>
                         </Button>
                       </CardContent>
                     </Card>

--- a/green-tech-africa/src/pages/account/MyProperties.tsx
+++ b/green-tech-africa/src/pages/account/MyProperties.tsx
@@ -2,32 +2,39 @@ import Layout from "@/components/layout/Layout";
 import PropertyCard from "@/components/properties/PropertyCard";
 import { useMyProperties } from "@/hooks/useProperties";
 import { Skeleton } from "@/components/ui/skeleton";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
+import { Home } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 
 const MyProperties = () => {
   const { data, isLoading } = useMyProperties();
+  const properties = data?.results ?? [];
 
   return (
     <Layout>
-      <section className="py-12 bg-accent/20">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold mb-4">My Properties</h1>
-          <p className="text-muted-foreground max-w-2xl">
-            Properties you own or have purchased through our platform.
-          </p>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="My Properties"
+        description="Properties you own or purchased through Green Tech Africa."
+        icon={<Home className="h-3.5 w-3.5" />}
+        actions={
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/account/properties">Browse Catalog</Link>
+          </Button>
+        }
+      />
 
-      <section className="py-12">
+      <section className="py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {isLoading ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3].map((i) => (
-                <Skeleton key={i} className="h-[400px] w-full rounded-lg" />
+                <Skeleton key={i} className="h-[380px] w-full rounded-xl" />
               ))}
             </div>
-          ) : data?.results && data.results.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {data.results.map((property) => (
+          ) : properties.length > 0 ? (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {properties.map((property) => (
                 <PropertyCard
                   key={property.id}
                   id={property.id}
@@ -49,8 +56,11 @@ const MyProperties = () => {
               ))}
             </div>
           ) : (
-            <div className="text-center py-20 bg-muted/30 rounded-lg border-2 border-dashed">
+            <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 py-16 text-center">
               <p className="text-muted-foreground mb-4">You don't have any properties yet.</p>
+              <Button asChild>
+                <Link to="/account/properties">Browse Properties</Link>
+              </Button>
             </div>
           )}
         </div>

--- a/green-tech-africa/src/pages/account/Payments.tsx
+++ b/green-tech-africa/src/pages/account/Payments.tsx
@@ -1,6 +1,8 @@
 import Layout from "@/components/layout/Layout";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { CreditCard } from "lucide-react";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 
 const INVOICES = [
   { id: "INV-9001", quoteId: "QUO-551", amount: 25000, currency: "USD", status: "unpaid" },
@@ -10,15 +12,15 @@ const INVOICES = [
 const Payments = () => {
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-2xl md:text-3xl font-bold">Payments</h1>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="Payments"
+        description="Track invoice statuses and complete pending payments securely."
+        icon={<CreditCard className="h-3.5 w-3.5" />}
+      />
       <section className="py-8">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3">
           {INVOICES.map((inv) => (
-            <Card key={inv.id} className="shadow-soft">
+            <Card key={inv.id} className="border-border/70 shadow-soft">
               <CardContent className="p-4 flex items-center justify-between text-sm">
                 <div>
                   <div className="font-medium">{inv.id} • {inv.currency} {inv.amount.toLocaleString()}</div>

--- a/green-tech-africa/src/pages/account/ProjectsCatalog.tsx
+++ b/green-tech-africa/src/pages/account/ProjectsCatalog.tsx
@@ -5,22 +5,18 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { 
   Building2, 
-  Home, 
-  Factory, 
   MapPin, 
   Calendar, 
   Search,
-  Heart,
   Loader2
 } from "lucide-react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { publicApi, type PaginatedProjectsResponse } from "@/lib/api";
-import { useToast } from "@/components/ui/use-toast";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 import { useState } from "react";
 
 const ProjectsCatalog = () => {
-  const { toast } = useToast();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchTerm, setSearchTerm] = useState(searchParams.get('search') || '');
@@ -71,22 +67,15 @@ const ProjectsCatalog = () => {
   return (
     <Layout>
       <div className="min-h-screen bg-background">
-        {/* Hero Section */}
-        <section className="py-12 bg-gradient-to-br from-primary/5 via-background to-background">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="text-center mb-8">
-              <Badge variant="outline" className="mb-4">
-                <Building2 className="w-3 h-3 mr-1" />
-                Projects Catalog
-              </Badge>
-              <h1 className="text-4xl font-bold mb-4">Browse Construction Projects</h1>
-              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-                Explore our portfolio of sustainable construction projects. Click "Request Similar Project" to get started.
-              </p>
-            </div>
+        <AccountPageHeader
+          title="Projects Catalog"
+          description="Discover project references and request similar work from your account workspace."
+          icon={<Building2 className="h-3.5 w-3.5" />}
+        />
 
-            {/* Search and Category Filters */}
-            <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <section className="py-6 border-b">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col md:flex-row gap-4 mb-4">
               <div className="flex-1 relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-5 h-5" />
                 <Input
@@ -100,8 +89,7 @@ const ProjectsCatalog = () => {
               <Button onClick={handleSearch}>Search</Button>
             </div>
 
-            {/* Category Tabs */}
-            <div className="flex flex-wrap gap-2 justify-center">
+            <div className="flex flex-wrap gap-2">
               {['all', 'residential', 'commercial', 'industrial', 'infrastructure'].map((cat) => (
                 <Button
                   key={cat}
@@ -146,7 +134,7 @@ const ProjectsCatalog = () => {
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {projects.map((project) => (
-                <Card key={project.id} className="overflow-hidden hover:shadow-lg transition-shadow">
+                <Card key={project.id} className="overflow-hidden border-border/70 shadow-soft smooth-transition hover:-translate-y-0.5 hover:shadow-medium">
                   {project.featured_image && (
                     <div className="aspect-video relative overflow-hidden">
                       <img

--- a/green-tech-africa/src/pages/account/PropertiesCatalog.tsx
+++ b/green-tech-africa/src/pages/account/PropertiesCatalog.tsx
@@ -3,19 +3,17 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Search, Filter, Heart, MapPin, Home, Bed, Bath, Square } from "lucide-react";
+import { Search, Heart, MapPin, Home, Bed, Bath, Square } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { getFavorites, toggleFavorite } from "@/lib/favorites";
 import { useToast } from "@/components/ui/use-toast";
-import PropertyCard from "@/components/properties/PropertyCard";
 import PropertyFilters from "@/components/properties/PropertyFilters";
 import { useProperties } from "@/hooks/useProperties";
-import { useAuth } from "@/contexts/AuthContext";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 
 const PropertiesCatalog = () => {
   const { toast } = useToast();
-  const { isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedType, setSelectedType] = useState("all");
@@ -51,22 +49,22 @@ const PropertiesCatalog = () => {
   return (
     <Layout>
       <div className="min-h-screen bg-background">
-        {/* Hero Section */}
-        <section className="py-12 bg-gradient-to-br from-primary/5 via-background to-background">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="text-center mb-8">
-              <Badge variant="outline" className="mb-4">
-                <Home className="w-3 h-3 mr-1" />
-                Property Catalog
-              </Badge>
-              <h1 className="text-4xl font-bold mb-4">Browse Available Properties</h1>
-              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-                Explore our curated selection of properties. Click "Request This Property" to submit your interest.
-              </p>
-            </div>
+        <AccountPageHeader
+          title="Properties Catalog"
+          description="Explore listings, compare options, and request a property directly from your account."
+          icon={<Home className="h-3.5 w-3.5" />}
+          actions={
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/account/favorites">
+                <Heart className="mr-2 h-4 w-4" /> View Favorites
+              </Link>
+            </Button>
+          }
+        />
 
-            {/* Search and Filters */}
-            <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <section className="border-b py-6">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col md:flex-row gap-4">
               <div className="flex-1 relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-5 h-5" />
                 <Input
@@ -96,12 +94,7 @@ const PropertiesCatalog = () => {
               <h2 className="text-2xl font-semibold">
                 {filteredProperties.length} {filteredProperties.length === 1 ? 'Property' : 'Properties'} Available
               </h2>
-              <Button variant="outline" size="sm" asChild>
-                <Link to="/account/favorites">
-                  <Heart className="w-4 h-4 mr-2" />
-                  View Favorites
-                </Link>
-              </Button>
+              <div className="text-sm text-muted-foreground">Use filters to refine your shortlist.</div>
             </div>
 
             {isLoading && (
@@ -125,7 +118,7 @@ const PropertiesCatalog = () => {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {filteredProperties.map((property) => (
                 <div key={property.id} className="relative">
-                  <Card className="group hover:shadow-elegant smooth-transition overflow-hidden">
+                  <Card className="group overflow-hidden border-border/70 shadow-soft smooth-transition hover:-translate-y-0.5 hover:shadow-medium">
                     <div className="relative overflow-hidden">
                       {property.featured_image && (
                         <img

--- a/green-tech-africa/src/pages/account/Quotes.tsx
+++ b/green-tech-africa/src/pages/account/Quotes.tsx
@@ -1,13 +1,14 @@
 import Layout from "@/components/layout/Layout";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { FileSpreadsheet, Filter } from "lucide-react";
+import { FileSpreadsheet, Plus } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import type { QuoteSummary, QuoteStatus } from "@/types/quote";
+import type { QuoteSummary } from "@/types/quote";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 
 const STATUS_BADGES: Record<string, { label: string; variant: "default" | "outline" | "secondary" | "destructive" }> = {
   draft: { label: "Draft", variant: "outline" },
@@ -76,15 +77,18 @@ const Quotes = () => {
 
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <FileSpreadsheet className="w-6 h-6" />
-            <h1 className="text-2xl md:text-3xl font-bold">Quotes</h1>
-          </div>
-          <Button variant="outline" size="sm"><Filter className="w-4 h-4 mr-1" /> Filters</Button>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="Quotes"
+        description="Review estimates, monitor status changes, and open full quote details."
+        icon={<FileSpreadsheet className="h-3.5 w-3.5" />}
+        actions={
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/plans">
+              <Plus className="mr-1 h-4 w-4" /> Request New Quote
+            </Link>
+          </Button>
+        }
+      />
 
       <section className="py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3">
@@ -93,7 +97,7 @@ const Quotes = () => {
           {!isLoading && !error && visibleQuotes.map((quote) => {
             const badge = STATUS_BADGES[quote.status] || { label: quote.status, variant: "outline" as const };
             return (
-              <Card key={quote.id} className="shadow-soft hover:shadow-medium smooth-transition">
+              <Card key={quote.id} className="border-border/70 shadow-soft smooth-transition hover:-translate-y-0.5 hover:shadow-medium">
                 <CardContent className="p-4 flex items-center justify-between">
                   <div>
                     <div className="font-medium">{quote.reference} • {formatCurrency(quote.currency_code, quote.total_amount)}</div>

--- a/green-tech-africa/src/pages/account/Requests.tsx
+++ b/green-tech-africa/src/pages/account/Requests.tsx
@@ -3,11 +3,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { ClipboardList, Plus, Filter, Building2 } from "lucide-react";
+import { ClipboardList, Plus, Building2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { buildRequestsApi, BuildRequest, constructionRequestsApi, ConstructionRequest } from "@/lib/api";
 import { Loader2 } from "lucide-react";
+import AccountPageHeader from "@/components/account/AccountPageHeader";
 
 const buildRequestStatusLabel = (status: string) => {
   switch (status) {
@@ -164,28 +165,25 @@ const Requests = () => {
 
   return (
     <Layout>
-      <section className="py-10 bg-gradient-to-br from-background via-accent/30 to-background">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <ClipboardList className="w-6 h-6" />
-              <h1 className="text-2xl md:text-3xl font-bold">My Requests</h1>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" asChild>
-                <Link to="/account/construction-requests/new">
-                  <Plus className="w-4 h-4 mr-1" /> New Construction Request
-                </Link>
-              </Button>
-              <Button variant="hero" size="sm" asChild>
-                <Link to="/plans">
-                  <Plus className="w-4 h-4 mr-1" /> Browse Plans
-                </Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
+      <AccountPageHeader
+        title="My Requests"
+        description="Track build and construction requests, status updates, and next actions."
+        icon={<ClipboardList className="h-3.5 w-3.5" />}
+        actions={
+          <>
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/account/construction-requests/new">
+                <Plus className="mr-1 h-4 w-4" /> New Construction Request
+              </Link>
+            </Button>
+            <Button variant="hero" size="sm" asChild>
+              <Link to="/plans">
+                <Plus className="mr-1 h-4 w-4" /> Browse Plans
+              </Link>
+            </Button>
+          </>
+        }
+      />
 
       <section className="py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/green-tech-africa/src/pages/plans/Plans.tsx
+++ b/green-tech-africa/src/pages/plans/Plans.tsx
@@ -74,11 +74,12 @@ const Plans = () => {
 
   return (
     <Layout>
-      <section className="relative py-16 bg-gradient-to-br from-background via-accent/30 to-background">
+      <section className="relative py-14 bg-gradient-to-br from-background via-accent/30 to-background border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center max-w-3xl mx-auto">
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">Building Plans</h1>
-            <p className="text-muted-foreground text-lg">Explore modern, efficient designs. Start a request with one click.</p>
+          <div className="max-w-3xl">
+            <div className="mb-2 inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">Customer Plans Flow</div>
+            <h1 className="text-4xl md:text-5xl font-bold mb-3">Building Plans</h1>
+            <p className="text-muted-foreground text-lg">Explore modern, efficient designs and move directly to request-to-build.</p>
           </div>
         </div>
       </section>
@@ -157,7 +158,7 @@ const Plans = () => {
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {plans.map((plan) => (
-                    <Card key={plan.id} className="overflow-hidden shadow-medium hover-lift smooth-transition group">
+                    <Card key={plan.id} className="group overflow-hidden border-border/70 shadow-soft smooth-transition hover:-translate-y-0.5 hover:shadow-medium">
                       <div className="relative overflow-hidden">
                         <img src={plan.hero_image} alt={plan.name} className="w-full h-44 object-cover group-hover:scale-105 smooth-transition" />
                         <div className="absolute top-4 left-4">


### PR DESCRIPTION
### Motivation
- Finish the modern in-app UX pass for the remaining customer flows so account users see a consistent header, search/filters, card surfaces and empty-state/actions across Properties, Projects, Plans and related pages.
- Reduce visual fragmentation between public and authenticated experiences by centralizing the account page header and harmonizing card elevation, spacing and interaction patterns.
- Improve discoverability and conversion for request/plan flows by tightening the search/filter bands and surfacing clear CTAs from account screens.

### Description
- Added a reusable `AccountPageHeader` component (`src/components/account/AccountPageHeader.tsx`) and applied it across account pages to unify title, description, icon and contextual actions.
- Modernized customer pages and flows including `PropertiesCatalog`, `ProjectsCatalog`, `MyProperties`, `MyProjects`, `Requests`, `Quotes`, `Messages`, `Documents`, `Favorites`, `Payments`, `Appointments`, and `Dashboard` to use the new header and updated card/empty-state treatments; updated `Plans` hero and plan cards to support the request-to-build journey.
- Refactored layout and navigation visuals and behavior: updated `Layout.tsx`, `Navbar.tsx`, `Sidebar.tsx`, and `Footer.tsx` to improve active-route detection, collapse styling, header/footer behavior for authenticated vs public users, and overall surface styling (shadows/borders/hover states).
- Small component/section polish across public areas for consistency: `Hero`, `FeaturedProjects`, `ServicesOverview`, and `Testimonials` (adjusted spacing, badges, card surfaces and CTA treatments).

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. ✅
- Started the dev server and executed a Playwright script that loaded `/account/properties` and captured a full-page screenshot saved at `browser:/tmp/codex_browser_invocations/f87a8d40fa2d5b29/artifacts/artifacts/customer-inapp-properties-catalog.png`, which completed successfully. ✅
- No unit tests were changed; visual/functional validation was performed via the local build and the automated Playwright screenshot which succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967a9f5ac883269f189e4662c03632)